### PR TITLE
Replace broken magic number with constant

### DIFF
--- a/scripts/generate_rules.php
+++ b/scripts/generate_rules.php
@@ -41,7 +41,7 @@ foreach($objects as $name => $object){
 	}
 
 	foreach(token_get_all($file_content) as $token) {
-		if ($token[0] != 319) {
+		if ($token[0] !== T_STRING) {
 			continue;
 		}
 


### PR DESCRIPTION
PHP's parser token constants are dynamically generated,
values can change from version to version.

In PHP 7.4 `T_STRING` is not `319` and the rule generation script fails to work.

See: https://www.php.net/manual/en/tokens.php
